### PR TITLE
Add button color and text fields to event config comments

### DIFF
--- a/app/Http/Controllers/AppControllers/EventConfigCommentsController.php
+++ b/app/Http/Controllers/AppControllers/EventConfigCommentsController.php
@@ -22,6 +22,10 @@ class EventConfigCommentsController extends Controller
     public function index(Events $event): EventConfigCommentResource|JsonResponse
     {
         try {
+            if (!$event->eventConfigComment()->exists()) {
+                return response()->json(['data' => [], 'message' => 'Event config comment not found'], 404);
+            }
+            
             return EventConfigCommentResource::make($event->eventConfigComment);
         } catch (Throwable $th) {
             return response()->json(['message' => $th->getMessage(), 'data' => []], 500);
@@ -47,6 +51,7 @@ class EventConfigCommentsController extends Controller
      * Update event comments configuration.
      * @param StoreEventConfigCommentRequest $request
      * @param Events $event
+     * @param EventConfigComment $commentConfig
      * @return JsonResponse|EventResource
      */
     public function update(StoreEventConfigCommentRequest $request, Events $event, EventConfigComment $commentConfig): JsonResponse|EventConfigCommentResource

--- a/app/Http/Requests/app/StoreEventConfigCommentRequest.php
+++ b/app/Http/Requests/app/StoreEventConfigCommentRequest.php
@@ -26,6 +26,8 @@ class StoreEventConfigCommentRequest extends FormRequest
             'subTitle' => 'required|string',
             'backgroundColor' => 'required|string',
             'commentsTitle' => 'required|string',
+            'buttonColor' => 'required|string',
+            'buttonText' => 'required|string',
             'maxComments' => 'required|numeric',
         ];
     }

--- a/app/Http/Resources/AppResources/EventConfigCommentResource.php
+++ b/app/Http/Resources/AppResources/EventConfigCommentResource.php
@@ -20,6 +20,8 @@ class EventConfigCommentResource extends JsonResource
             'subTitle' => $this->sub_title,
             'backgroundColor' => $this->background_color,
             'commentsTitle' => $this->comments_title,
+            'buttonColor' => $this->button_color,
+            'buttonText' => $this->button_text,
             'maxComments' => $this->max_comments,
             'created_at' => $this->created_at->diffForHumans(),
             'updated_at' => $this->updated_at->diffForHumans(),

--- a/app/Http/Services/AppServices/EventConfigCommentsServices.php
+++ b/app/Http/Services/AppServices/EventConfigCommentsServices.php
@@ -29,6 +29,8 @@ class EventConfigCommentsServices
             'sub_title' => $this->request->get('subTitle'),
             'background_color' => $this->request->get('backgroundColor'),
             'comments_title' => $this->request->get('commentsTitle'),
+            'button_color' => $this->request->get('buttonColor'),
+            'button_text' => $this->request->get('buttonText'),
             'max_comments' => $this->request->get('maxComments'),
         ]);
     }
@@ -45,6 +47,8 @@ class EventConfigCommentsServices
       $eventConfigComment->sub_title = $this->request->get('subTitle');
       $eventConfigComment->background_color = $this->request->get('backgroundColor');
       $eventConfigComment->comments_title = $this->request->get('commentsTitle');
+      $eventConfigComment->button_color = $this->request->get('buttonColor');
+      $eventConfigComment->button_text = $this->request->get('buttonText');
       $eventConfigComment->max_comments = $this->request->get('maxComments');
       
       $eventConfigComment->save();

--- a/app/Models/EventConfigComment.php
+++ b/app/Models/EventConfigComment.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\SoftDeletes;
 
 class EventConfigComment extends Model
 {
@@ -20,6 +19,8 @@ class EventConfigComment extends Model
         'sub_title',
         'background_color',
         'comments_title',
+        'button_color',
+        'button_text',
         'max_comments',
     ];
   

--- a/database/migrations/2025_03_27_142828_create_event_config_comment_table.php
+++ b/database/migrations/2025_03_27_142828_create_event_config_comment_table.php
@@ -18,6 +18,8 @@ return new class extends Migration
             $table->string('sub_title');
             $table->string('background_color');
             $table->string('comments_title');
+            $table->string('button_color');
+            $table->string('button_text');
             $table->integer('max_comments');
             $table->timestamps();
         });


### PR DESCRIPTION
This commit introduces `buttonColor` and `buttonText` fields across the event configuration comments logic, including the database, request validation, models, resources, and services. It also adds a check to handle cases where event config comments do not exist, returning a 404 response when applicable.