### PR TITLE
Fix filesystem config for 'sweet-memories' storage driver

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -59,13 +59,15 @@ return [
         
         'sweet-memories' => [
             'driver' => env('SWEET_MEMORIES_DRIVER', 'local'),
-            'key' => env('AWS_SECRET_ACCESS_KEY'),
+            'key' => env('AWS_ACCESS_KEY_ID'), // Fix this to use the correct key
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
-            'root' => env('SWEET_MEMORIES_ROOT', storage_path('app/public/sweet-memories')),
-            'url' => env('SWEET_MEMORIES_URL', env('APP_URL').'/storage/sweet-memories'),
-            'visibility' => 'public',
+            'root' => env('SWEET_MEMORIES_DRIVER') === 'local'
+                ? env('SWEET_MEMORIES_ROOT', storage_path('app/public/sweet-memories'))
+                : null,
+            'url' => env('AWS_URL', env('APP_URL').'/storage/sweet-memories'),
+            'endpoint' => env('AWS_ENDPOINT'),
             'throw' => true,
         ]
     ],


### PR DESCRIPTION
Corrected the environment key for AWS_ACCESS_KEY_ID and updated configuration to handle 'local' and S3 drivers properly. Added support for AWS-specific settings like endpoint and simplified URL handling. This ensures better flexibility and resolves potential misconfigurations.