### PR TITLE
Update session 'same_site' to use environment variable

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -196,6 +196,6 @@ return [
     |
     */
 
-    'same_site' => 'lax',
+    'same_site' => env('SAME_SITE', 'lax'),
 
 ];


### PR DESCRIPTION
Replaced the hardcoded 'same_site' value with an environment variable. This allows greater flexibility and easier configuration across different environments. The default remains 'lax' if the environment variable is not set.