### PR TITLE
Update Sweet Memories storage configuration and logging

### DIFF
--- a/app/Http/Resources/AppResources/SweetMemoriesImageResource.php
+++ b/app/Http/Resources/AppResources/SweetMemoriesImageResource.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources\AppResources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
 class SweetMemoriesImageResource extends JsonResource
@@ -17,6 +18,13 @@ class SweetMemoriesImageResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        Log::debug("SweetMemoriesImageResource::toArray()", [
+                'driver' => config('filesystems.disks.sweet-memories.driver'),
+                'env_value' => env('SWEET_MEMORIES_DRIVER'),
+                'filesystem_disk' => config('filesystems.default'),
+            ]
+        );
+        
         return [
             'id' => $this->id,
             'imagePath' => Storage::disk(self::STORAGE_DISK)->url($this->image_path),

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -59,14 +59,16 @@ return [
         
         'sweet-memories' => [
             'driver' => env('SWEET_MEMORIES_DRIVER', 'local'),
-            'key' => env('AWS_ACCESS_KEY_ID'), // Fix this to use the correct key
+            'key' => env('AWS_ACCESS_KEY_ID'),
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
             'root' => env('SWEET_MEMORIES_DRIVER') === 'local'
                 ? env('SWEET_MEMORIES_ROOT', storage_path('app/public/sweet-memories'))
                 : null,
-            'url' => env('AWS_URL', env('APP_URL').'/storage/sweet-memories'),
+            'url' => (env('SWEET_MEMORIES_DRIVER') === 'local')
+                ? env('APP_URL').'/storage/sweet-memories'
+                : env('AWS_URL'),
             'endpoint' => env('AWS_ENDPOINT'),
             'throw' => true,
         ]


### PR DESCRIPTION
Refine the Sweet Memories disk configuration to use consistent URL paths based on the driver. Add debug logging in `SweetMemoriesImageResource` to track storage driver and environment variables for better traceability.