### PR TITLE
Add last_active_event_id to users table and update token logic

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -158,7 +158,14 @@ class AuthenticationController extends Controller
             return response()->json(['message' => 'Access Denied. You are not authorized to access this page.'], 403);
         }
 
-        $token = $user->createToken($request->input('device'))->plainTextToken;
+        $remember = $request->input('remember', false);
+        $expiration = $remember ? now()->addDays(30) : now()->addhours(5);
+        
+        $token = $user->createToken(
+            $request->input('device'),
+            ['*'],
+            $expiration
+        )->plainTextToken;
 
         UserLoggedInEvent::dispatch($user, $request);
         

--- a/database/migrations/2025_04_19_025901_add_last_active_event_id_to_users_table.php
+++ b/database/migrations/2025_04_19_025901_add_last_active_event_id_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedInteger('last_active_event_id')->after('remember_token')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('last_active_event_id');
+        });
+    }
+};


### PR DESCRIPTION
This commit introduces a migration to add a nullable `last_active_event_id` column to the `users` table. It also updates the token generation in `AuthenticationController` to support an optional "remember me" feature, allowing tokens to expire in 30 days or 5 hours based on user input. These changes enhance user session management and tracking of activity events.