### PR TITLE
Add guest deletion functionality

### DIFF
--- a/app/Http/Controllers/AppControllers/GuestController.php
+++ b/app/Http/Controllers/AppControllers/GuestController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\app\StoreGuestRequest;
 use App\Http\Resources\AppResources\GuestResource;
 use App\Http\Services\AppServices\GuestServices;
 use App\Models\Events;
+use App\Models\Guest;
 use App\Models\MainGuest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -43,6 +44,23 @@ class GuestController extends Controller
             return response()->json(['message' => $th->getMessage(), 'data' => []], 500);
         }
     }
+    
+    /**
+     * Remove a guest from the event.
+     * @param Events $event
+     * @param Guest $guest
+     * @return JsonResponse
+     */
+    public function destroy(Events $event, Guest $guest): JsonResponse
+    {
+        try {
+            $this->guestServices->delete($guest);
+            return response()->json(['message' => 'Guest deleted successfully', 'data' => []], 200);
+        } catch (Throwable $th) {
+            return response()->json(['message' => $th->getMessage(), 'data' => []], 500);
+        }
+    }
+    
     
     /**
      * Update the companion type for a main guest.

--- a/app/Http/Services/AppServices/GuestServices.php
+++ b/app/Http/Services/AppServices/GuestServices.php
@@ -180,5 +180,16 @@ class GuestServices
                 ->delete();
         }
     }
+    
+    /**
+     * Deletes the specified guest from the database.
+     *
+     * @param Guest $guest The guest instance to be deleted.
+     * @return void
+     */
+    public function delete(Guest $guest): void
+    {
+        $guest->delete();
+    }
 
 }

--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -63,15 +63,15 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('event/{event}/save-the-date', [SaveTheDateController::class, 'store']);
     Route::put('save-the-date/{saveTheDate}', [SaveTheDateController::class, 'update']);
     
-    Route::post('event/{event}/guest', [GuestController::class, 'store']);
-    
     
     Route::get('event/{event}/rsvp', [RsvpController::class, 'index']);
     
-    Route::get('event/{event}/guest', [GuestController::class, 'index'])
+    Route::get('event/{event}/guests', [GuestController::class, 'index'])
         ->name('index.guests');
     Route::post('event/{event}/guests', [GuestController::class, 'store'])
         ->name('guests.store');
+    Route::delete('event/{event}/guests/{guest}', [GuestController::class, 'destroy'])
+        ->name('guests.destroy');
     
     Route::patch('guest/{guest}', [GuestController::class, 'updateCompanion'])
         ->name('guest.updateCompanion');


### PR DESCRIPTION
Introduced a method to delete guests in `GuestServices` and corresponding API endpoint in `GuestController`. Updated route definitions to support deleting specific guests tied to an event. This allows for proper handling of guest removal with appropriate error responses.