### PR TITLE
Add support for event location images and related APIs

### DIFF
--- a/app/Http/Requests/StoreEventLocationRequest.php
+++ b/app/Http/Requests/StoreEventLocationRequest.php
@@ -11,9 +11,17 @@ class StoreEventLocationRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
-
+    
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'isDefault' => filter_var($this->isDefault, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)
+        ]);
+    }
+    
+    
     /**
      * Get the validation rules that apply to the request.
      *
@@ -26,11 +34,13 @@ class StoreEventLocationRequest extends FormRequest
             'address' => 'required|string|max:255',
             'city' => 'required|string|max:255',
             'state' => 'required|string|max:255',
-            'zip_code' => 'required|string|max:10',
+            'zipCode' => 'required|string|max:10',
             'country' => 'required|string|max:255',
             'latitude' => 'required|numeric',
             'longitude' => 'required|numeric',
-            'is_default' => 'required|boolean',
+            'isDefault' => 'nullable|boolean',
+            'images.*' => 'nullable|image|max:2048',
+            'google_photos' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Resources/AppResources/EventLocationResource.php
+++ b/app/Http/Resources/AppResources/EventLocationResource.php
@@ -4,8 +4,7 @@ namespace App\Http\Resources\AppResources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
-use Illuminate\Support\Facades\Log;
-use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
 
 class EventLocationResource extends JsonResource
 {
@@ -23,11 +22,11 @@ class EventLocationResource extends JsonResource
             'address' => $this->address,
             'city' => $this->city,
             'state' => $this->state,
-            'zip_code' => $this->zip_code,
+            'zipCode' => $this->zip_code,
             'country' => $this->country,
             'latitude' => $this->latitude,
             'longitude' => $this->longitude,
-            'is_default' => $this->is_default,
+            'isDefault' => $this->is_default,
         ];
     }
     

--- a/app/Models/EventLocation.php
+++ b/app/Models/EventLocation.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class EventLocation extends Model
 {
@@ -34,5 +35,15 @@ class EventLocation extends Model
     public function event(): BelongsTo
     {
         return $this->belongsTo(Events::class, 'event_id', 'id');
+    }
+    
+    /**
+     * Define a one-to-many relationship with the EventLocationImages model.
+     *
+     * @return HasMany
+     */
+    public function eventLocationImages(): HasMany
+    {
+        return $this->hasMany(EventLocationImages::class, 'event_location_id', 'id');
     }
 }

--- a/app/Models/EventLocationImages.php
+++ b/app/Models/EventLocationImages.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EventLocationImages extends Model
+{
+    /** @use HasFactory<\Database\Factories\EventLocationFactory> */
+    use HasFactory;
+    
+    protected $table = 'event_location_images';
+    
+    protected $fillable = [
+        'event_location_id',
+        'path',
+        'caption',
+        'order',
+        'source',
+    ];
+    
+    /**
+     * Define a relationship to the Events model.
+     *
+     * @return BelongsTo
+     */
+    public function eventLocation(): BelongsTo
+    {
+        return $this->belongsTo(EventLocation::class, 'event_id', 'id');
+    }
+}

--- a/database/migrations/2025_04_29_013356_create_event_locations_table.php
+++ b/database/migrations/2025_04_29_013356_create_event_locations_table.php
@@ -20,7 +20,6 @@ return new class extends Migration
             $table->string('state'); // State or province
             $table->string('zip_code'); // Postal code
             $table->string('country'); // Country
-            $table->string('image_path')->nullable(); // Path to an image of the location
             $table->text('notes')->nullable(); // Additional notes about the location
             $table->string('phone')->nullable(); // Phone number for the location
             $table->decimal('latitude', 10, 8)->nullable(); // Latitude for geolocation

--- a/database/migrations/2025_04_29_125630_create_location_images_table.php
+++ b/database/migrations/2025_04_29_125630_create_location_images_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_location_images', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_location_id')
+                ->references('id')
+                ->on('event_locations')
+                ->onDelete('cascade');
+            
+            $table->text('path');
+            $table->string('caption')->nullable();
+            $table->integer('order')->default(0);
+            $table->string('source')->default('uploaded');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_location_images');
+    }
+};

--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -118,6 +118,11 @@ Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
     
     Route::get('event/{event}/locations', [EventLocationController::class, 'index'])
         ->name('index.eventLocations');
+    Route::post('event/{event}/locations', [EventLocationController::class, 'store'])
+        ->name('store.eventLocations');
+    Route::delete('event/{event}/locations/{location}', [EventLocationController::class, 'destroy'])
+        ->name('destroy.eventLocations');
+    
     
     Route::post('event/{event}/sweet-memories-images', [SweetMemoriesImageController::class, 'store'])
         ->name('store.sweetMemoriesImages');


### PR DESCRIPTION
Introduced a new `event_location_images` table and its model to handle images associated with event locations. Updated the event location creation process to support uploading images and storing Google Photos links. Adjusted validation, resource, and API routes for seamless integration.