### PR TITLE
Add revert RSVP confirmation functionality

### DIFF
--- a/app/Models/Guest.php
+++ b/app/Models/Guest.php
@@ -19,6 +19,7 @@ class Guest extends Model
         'email',
         'phone',
         'rsvp_status',
+        'rsvp_status_date',
         'code',
         'notes',
         'is_vip',

--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -73,6 +73,9 @@ Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
         ->name('rsvp.guests');
     Route::get('event/{event}/rsvp/guests/totals', [RsvpController::class, 'getRsvpUsersTotals'])
         ->name('rsvp.guests.totals');
+    Route::post('event/{event}/rsvp/guests/{guest}/revert-confirmation', [RsvpController::class, 'revertConfirmation'])
+        ->name('rsvp.revertConfirmation');
+    
     
     Route::get('event/{event}/rsvp/guests/download', [ExportController::class, 'handleExportRequest'])
         ->name('rsvp.request.export');


### PR DESCRIPTION
Introduced a new method `revertConfirmation` in `RsvpController` to allow reverting a guest's RSVP status and that of their companions to "pending." Updated `Guest` model to include `rsvp_status_date` and registered the new API route for this functionality.