### PR TITLE
Add endpoints and resources for event plans and types

### DIFF
--- a/app/Http/Controllers/AppControllers/EventsController.php
+++ b/app/Http/Controllers/AppControllers/EventsController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers\AppControllers;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\app\StoreEventsRequest;
 use App\Http\Requests\app\UpdateEventsRequest;
+use App\Http\Resources\AppResources\EventPlansResource;
 use App\Http\Resources\AppResources\EventResource;
+use App\Http\Resources\AppResources\EventTypesResource;
 use App\Http\Services\AppServices\EventsServices;
 use App\Models\Events;
 use Illuminate\Http\JsonResponse;
@@ -136,4 +138,27 @@ class EventsController extends Controller
             return response()->json(['message' => $th->getMessage(), 'data' => []], 500);
         }
     }
+    
+    /**
+     * Retrieve event types and loan plans.
+     * @return JsonResponse
+     */
+    public function loanEventsPlansAndType(): JsonResponse
+    {
+        try {
+            $eventTypes = $this->eventsServices->getEventTypes();
+            $eventPlans = $this->eventsServices->getEventPlans();
+            
+            return response()->json([
+                'message' => 'Event types and loan plans retrieved successfully.',
+                'data' => [
+                    'eventTypes' =>  EventTypesResource::collection($eventTypes),
+                    'eventPlans' => EventPlansResource::collection($eventPlans),
+                ]
+            ]);
+        } catch (Throwable $th) {
+            return response()->json(['message' => $th->getMessage(), 'data' => []], 500);
+        }
+    }
+    
 }

--- a/app/Http/Resources/AppResources/EventPlansResource.php
+++ b/app/Http/Resources/AppResources/EventPlansResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources\AppResources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class EventPlansResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'slug' => $this->slug,
+            'hasGallery' => $this->has_gallery,
+            'hasMusic' => $this->has_music,
+            'hasCustomDesign' => $this->has_custom_design,
+            'hasDragEditor' => $this->has_drag_editor,
+            'hasAiAssistant' => $this->has_ai_assistant,
+            'hasInvitations' => $this->has_invitations,
+            'hasSms' => $this->has_sms,
+            'hasGiftRegistry' => $this->has_gift_registry,
+            'supportLevel' => $this->support_level,
+        ];
+    }
+}

--- a/app/Http/Resources/AppResources/EventTypesResource.php
+++ b/app/Http/Resources/AppResources/EventTypesResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\AppResources;
+
+use App\Http\Resources\UserResource;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class EventTypesResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'icon' => $this->icon,
+        ];
+    }
+}

--- a/app/Http/Services/AppServices/EventsServices.php
+++ b/app/Http/Services/AppServices/EventsServices.php
@@ -3,7 +3,9 @@
 namespace App\Http\Services\AppServices;
 
 use App\Models\EventFeature;
+use App\Models\EventPlan;
 use App\Models\Events;
+use App\Models\EventType;
 use App\Models\User;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
@@ -173,5 +175,26 @@ class EventsServices
             Log::error($e->getMessage());
             return false;
         }
+    }
+    
+    /**
+     * Retrieve all event types.
+     * @return Collection
+     */
+    public function getEventTypes(): Collection
+    {
+        return EventType::query()
+            ->select('id', 'name', 'slug', 'icon')
+            ->get();
+    }
+    
+    /**
+     * Retrieve all event plans.
+     *
+     * @return Collection
+     */
+    public function getEventPlans(): Collection
+    {
+        return EventPlan::query()->get();
     }
 }

--- a/database/seeders/EventPlanSeeder.php
+++ b/database/seeders/EventPlanSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 use App\Models\EventPlan;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class EventPlanSeeder extends Seeder

--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -58,6 +58,9 @@ Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
     
     Route::get('events', [EventsController::class, 'index']);
     
+    Route::get('events/load-events-plans-and-types', [EventsController::class, 'loanEventsPlansAndType'])
+        ->name('events.loanEventsPlansAndType');
+    
     
     Route::get('event/filters', [EventsController::class, 'filterEvents']);
     Route::delete('event/{event}', [EventsController::class, 'destroy']);


### PR DESCRIPTION
Introduced `EventPlansResource` and `EventTypesResource` to format responses. Added a new API endpoint to retrieve event types and plans, along with corresponding service methods in `EventsServices` and controller logic in `EventsController`. Minor cleanup in `EventPlanSeeder`.