### PR TITLE
Fix incorrect route name for updating background music

### DIFF
--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -128,7 +128,7 @@ Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
     Route::post('event/{event}/background-music', [BackgroundMusicController::class, 'store'])
         ->name('store.backgroundMusic');
     Route::post('background-music/{backgroundMusic}', [BackgroundMusicController::class, 'update'])
-        ->name('store.backgroundMusic');
+        ->name('update.backgroundMusic');
     
     Route::get('event/{event}/comments-config', [EventConfigCommentsController::class, 'index'])
         ->name('index.configComments');


### PR DESCRIPTION
The route for updating background music had a duplicate name (`store.backgroundMusic`). This has been corrected to `update.backgroundMusic` to reflect its purpose and ensure proper routing functionality.