### PR TITLE
Rename route name for updating Sweet Memories image names

### DIFF
--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -164,7 +164,7 @@ Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
         ->name('destroy.sweetMemoriesImages');
     
     Route::patch('sweet-memories-images/{sweetMemoriesImage}', [SweetMemoriesImageController::class, 'updateName'])
-        ->name('update.sweetMemoriesImages');
+        ->name('update.sweetMemoriesImages.name');
     
     Route::post('user/update-profile', [UserSettingsController::class, 'updateProfile'])
         ->name('user.updateProfile');


### PR DESCRIPTION
The route name for updating Sweet Memories image names was updated to be more specific (`update.sweetMemoriesImages.name`). This change improves clarity and consistency in route naming conventions.