### PR TITLE
Refactor menu management to support multiple menus per event

### DIFF
--- a/app/Http/Controllers/AppControllers/MenuController.php
+++ b/app/Http/Controllers/AppControllers/MenuController.php
@@ -70,9 +70,6 @@ class MenuController extends Controller
             ]);
         }
         
-        
-        Log::info('MenuController@store', [ $data['isDefault'], 'checking' => $request->all()]);
-        
         $menu = $event->menus()->create([
             'title' => $data['title'],
             'description' => $data['description'],

--- a/app/Http/Controllers/AppControllers/MenuController.php
+++ b/app/Http/Controllers/AppControllers/MenuController.php
@@ -20,17 +20,15 @@ class MenuController extends Controller
     public function index(Request $request, Events $event): JsonResponse
     {
         try {
-            $menu = $event->menu;
-            if ($menu) {
-                $menu->load('menuItems');
-            } else {
-                return response()->json(['message' => 'There is no menu for this event.'], 404);
+            $menus = $event->menus()->with('menuItems')->get();
+            if (!$menus)  {
+                return response()->json(['message' => 'There is no menus for this event.'], 404);
             }
             Log::info('MenuController@index', [
                 'event_id' => $event->id,
-                'menus' => $menu,
+                'menus' => $menus,
             ]);
-            return response()->json($menu);
+            return response()->json($menus);
         } catch (\Throwable $e) {
             return response()->json(['message' => $e->getMessage()], 500);
         }
@@ -63,13 +61,24 @@ class MenuController extends Controller
             'description' => 'nullable|string',
             'allowMultipleChoices' => 'boolean',
             'allowCustomRequests' => 'boolean',
+            'isDefault' => 'boolean',
         ]);
         
-        $menu = $event->menu()->create([
+        if ($data['isDefault']) {
+            $event->menus()->update([
+                'is_default' => false,
+            ]);
+        }
+        
+        
+        Log::info('MenuController@store', [ $data['isDefault'], 'checking' => $request->all()]);
+        
+        $menu = $event->menus()->create([
             'title' => $data['title'],
             'description' => $data['description'],
             'allow_multiple_choices' => $data['allowMultipleChoices'] ?? false,
             'allow_custom_requests' => $data['allowCustomRequests'] ?? false,
+            'is_default' => $data['isDefault'] ?? false,
         ]);
         
         return response()->json($menu, 201);

--- a/app/Models/Events.php
+++ b/app/Models/Events.php
@@ -163,11 +163,10 @@ class Events extends Model
     
     /**
      * Get the main guest associated with the event.
-     * @return HasOne
      */
-    public function menu(): HasOne
+    public function menus(): HasMany
     {
-        return $this->hasOne(Menu::class, 'event_id', 'id');
+        return $this->hasMany(Menu::class, 'event_id', 'id');
     }
     
     /**

--- a/app/Models/Guest.php
+++ b/app/Models/Guest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Guest extends Model
 {
@@ -20,6 +21,7 @@ class Guest extends Model
         'phone',
         'rsvp_status',
         'rsvp_status_date',
+        'assigned_menu_id',
         'code',
         'notes',
         'is_vip',
@@ -86,8 +88,8 @@ class Guest extends Model
         return $this->belongsToMany(MenuItem::class, 'guest_menu')->withTimestamps();
     }
     
-    public function menuItems(): BelongsToMany
+    public function menuAssigned(): HasOne
     {
-        return $this->belongsToMany(MenuItem::class, 'guest_menu')->withTimestamps();
+        return $this->hasOne(Menu::class, 'menu_id', 'id');
     }
 }

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -20,6 +20,7 @@ class Menu extends Model
         'description',
         'allow_multiple_choices',
         'allow_custom_request',
+        'is_default',
     ];
     
     /**

--- a/database/migrations/2025_05_11_135023_add_is_default_to_menus_table.php
+++ b/database/migrations/2025_05_11_135023_add_is_default_to_menus_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->boolean('is_default')
+                ->default(false)
+                ->after('description')
+                ->comment('Indicates if this menu is the default menu for the event');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->dropColumn('is_default');
+        });
+    }
+};

--- a/database/migrations/2025_05_11_135859_add_assigned_menu_id_to_guest_table.php
+++ b/database/migrations/2025_05_11_135859_add_assigned_menu_id_to_guest_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('guests', function (Blueprint $table) {
+            $table->foreignId('assigned_menu_id')
+                ->nullable()
+                ->after('tags')
+                ->comment('The menu item assigned to this guest')
+                ->constrained('menu_items');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('guests', function (Blueprint $table) {
+            $table->dropForeign('assigned_menu_id');
+        });
+    }
+};

--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -125,15 +125,15 @@ Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
     Route::put('suggest-music-config/{suggestedMusicConfig}', [SuggestedMusicConfigController::class, 'update']);
     Route::delete('suggest-music-config/{suggestedMusicConfig}', [SuggestedMusicConfigController::class, 'destroy']);
     
-    Route::get('event/{event}/menu', [MenuController::class, 'index'])
+    Route::get('event/{event}/menus', [MenuController::class, 'index'])
         ->name('index.menu');
-    Route::post('event/{event}/menu', [MenuController::class, 'store'])
+    Route::post('event/{event}/menus', [MenuController::class, 'store'])
         ->name('store.menu');
-    Route::put('event/{event}/menu/{menu}', [MenuController::class, 'update'])
+    Route::put('event/{event}/menus/{menu}', [MenuController::class, 'update'])
         ->name('update.menu');
-    Route::delete('event/{event}/menu/{menu}', [MenuController::class, 'destroy'])
+    Route::delete('event/{event}/menus/{menu}', [MenuController::class, 'destroy'])
         ->name('destroy.menu');
-    Route::get('event/{event}/menu/{menu}', [MenuController::class, 'show'])
+    Route::get('event/{event}/menus/{menu}', [MenuController::class, 'show'])
         ->name('show.menu');
     
     Route::post('event/{event}/menu/{menu}/menu-item', [MenuItemController::class, 'store'])

--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -136,7 +136,7 @@ Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
     Route::get('event/{event}/menus/{menu}', [MenuController::class, 'show'])
         ->name('show.menu');
     
-    Route::post('event/{event}/menu/{menu}/menu-item', [MenuItemController::class, 'store'])
+    Route::post('event/{event}/menus/{menu}/menu-item', [MenuItemController::class, 'store'])
         ->name('store.menuItem');
     Route::delete('event/{event}/menu/{menu}/menu-item/{menuItem}', [MenuItemController::class, 'destroy'])
         ->name('destroy.menuItem');


### PR DESCRIPTION
Updated the system to allow events to manage multiple menus instead of a single menu. Added a new `is_default` column to the menus table to identify the default menu and an `assigned_menu_id` column to the guests table for menu assignment. Adjusted API routes, models, and controllers accordingly to reflect these changes.