### PR TITLE
Remove timestamps from EventResource serialization

### DIFF
--- a/app/Http/Resources/AppResources/EventResource.php
+++ b/app/Http/Resources/AppResources/EventResource.php
@@ -51,6 +51,8 @@ class EventResource extends JsonResource
             $eventFeaturesArray = $this->eventFeature->toArray();
             unset($eventFeaturesArray['id']);
             unset($eventFeaturesArray['event_id']);
+            unset($eventFeaturesArray['created_at']);
+            unset($eventFeaturesArray['updated_at']);
             
             foreach ($eventFeaturesArray as $key => $eventFeature) {
                 $eventFeatures[] = [


### PR DESCRIPTION
Excluded `created_at` and `updated_at` fields from the serialized output of EventResource. This ensures cleaner and more relevant data representation when handling event features.