### PR TITLE
Add event permissions endpoint and controller

### DIFF
--- a/app/Http/Controllers/AppControllers/EventPermissions/EventPermissionsController.php
+++ b/app/Http/Controllers/AppControllers/EventPermissions/EventPermissionsController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\AppControllers\EventPermissions;
+
+use App\Http\Controllers\Controller;
+use App\Http\Services\AppServices\EventsServices;
+use App\Models\Events;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class EventPermissionsController extends Controller
+{
+    public function __construct(private readonly EventsServices $eventsServices) {}
+    
+    
+    /**
+     * Get the permissions of the logged-in user for a specific event.
+     *
+     * @param Request $request
+     * @param Events $event
+     * @return JsonResponse
+     */
+    public function index(Request $request, Events $event): JsonResponse
+    {
+        $user = $request->user();
+        
+        if (!$user->hasEventRole($event)) {
+            return response()->json([
+                'message' => 'You do not have permission to access this event.',
+                'data' => [],
+            ], 403);
+        }
+        $permissions = $user->getEventPermissions($event);
+        
+        return response()->json([
+            'message' => 'Permissions retrieved successfully.',
+            'data' => [
+                'permissions' => $permissions,
+                'event' => $event,
+            ]
+        ]);
+    }
+    
+}

--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -6,7 +6,8 @@ use App\Http\Controllers\AppControllers\CompanionController;
     use App\Http\Controllers\AppControllers\EventCommentsController;
 use App\Http\Controllers\AppControllers\EventConfigCommentsController;
 use App\Http\Controllers\AppControllers\EventLocationController;
-use App\Http\Controllers\AppControllers\EventsController;
+    use App\Http\Controllers\AppControllers\EventPermissions\EventPermissionsController;
+    use App\Http\Controllers\AppControllers\EventsController;
 use App\Http\Controllers\AppControllers\ExportController;
 use App\Http\Controllers\AppControllers\GuestController;
 use App\Http\Controllers\AppControllers\Hydrate\HydrateController;
@@ -66,6 +67,9 @@ Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
     Route::get('user/hydrate/{user}', [HydrateController::class, 'hydrate'])
         ->name('user.hydrate');
 
+    Route::get('event/{event}/permissions', [EventPermissionsController::class, 'index'])
+        ->name('event.permissions');
+    
     Route::post('event', [EventsController::class, 'store']);
     Route::patch('event/active-event', [EventsController::class, 'activeEvent'])
         ->name('event.active-event');


### PR DESCRIPTION
Introduce a new `EventPermissionsController` to handle retrieving user-specific permissions for an event. Register the `/event/{event}/permissions` route, enabling users to query permissions, and ensure proper response handling, including unauthorized access.