### PR TITLE
Add support for declining invites and token validation endpoints

### DIFF
--- a/app/Http/Controllers/AppControllers/Collaborators/InviteCollaboratorController.php
+++ b/app/Http/Controllers/AppControllers/Collaborators/InviteCollaboratorController.php
@@ -69,18 +69,56 @@ class InviteCollaboratorController extends Controller
      * @param string $token The invitation token used to locate the specific invitation.
      * @return JsonResponse A JSON response containing invitation details or an error message.
      */
-    public function show(string $token): JsonResponse
+    public function checkToken(Events $event, string $token): JsonResponse
     {
-        $invite = EventCollaborationInvite::query()->where('token', $token)->valid()->first();
+        $invite = EventCollaborationInvite::query()
+            ->where('token', $token)
+            ->first();
         
         if (!$invite) {
-            return response()->json(['message' => 'Invalid or expired invitation.'], 404);
+            return response()->json(['message' => 'Invalid or expired invitation.'], 422);
         }
         
         return response()->json([
+            'id' => $invite->id,
             'email' => $invite->email,
-            'event' => $invite->event->only(['id', 'name']),
+            'event' => $invite->event->only(['id', 'event_name']),
             'role' => $invite->role,
+            'status' => $invite->status,
+            'token' => $invite->token,
+        ]);
+    }
+    
+    /**
+     * Handles the decline of an event collaboration invite.
+     *
+     * This function validates an event collaboration invite token and marks the invite as declined.
+     * It returns a JSON response indicating the success or failure of the operation.
+     *
+     * @param Events $event The event for which the invite is being declined.
+     * @param string $token The token associated with the invite.
+     * @return JsonResponse A JSON response indicating the success or failure of the operation.
+     */
+    public function declineInvite(Events $event, string $token): JsonResponse
+    {
+        $invite = EventCollaborationInvite::query()
+            ->where('token', $token)
+            ->valid()
+            ->first();
+        
+        if (!$invite) {
+            return response()->json(['message' => 'Invalid or expired invitation.'], 422);
+        }
+        
+        $invite->markAsDeclined();
+        
+        return response()->json([
+            'id' => $invite->id,
+            'email' => $invite->email,
+            'event' => $invite->event->only(['id', 'event_name']),
+            'role' => $invite->role,
+            'status' => $invite->status,
+            'token' => $invite->token,
         ]);
     }
     
@@ -116,6 +154,44 @@ class InviteCollaboratorController extends Controller
         
         return response()->json(['message' => 'You have been added as a collaborator.']);
     }
+    
+    /**
+     * Retrieve and display event collaboration invitations based on provided tokens.
+     *
+     * This method handles a batch retrieval of event collaboration invitations using the provided tokens.
+     * It checks each token's validity and retrieves relevant invitations. If no valid invitations are found,
+     * a 404 JSON response with an error message is returned. Otherwise, a transformed collection of invitation details
+     * is returned in the response.
+     *
+     * @param Request $request The incoming request containing the tokens needed to find invitations.
+     * @return JsonResponse A JSON response containing a collection of transformed invitation data or an error message.
+     */
+    public function eventTokens(Request $request): JsonResponse
+    {
+        $invites = EventCollaborationInvite::query()
+            ->whereIn('token', $request->tokens)
+            ->valid()
+            ->get();
+        
+        if (!$invites) {
+            return response()->json(['message' => 'Invalid or expired invitation.'], 404);
+        }
+        
+        $invitesTransformed = $invites->map(function ($invite) {
+            return [
+                'id' => $invite->id,
+                'email' => $invite->email,
+                'event' => $invite->event->only(['id', 'event_name']),
+                'role' => $invite->role,
+                'status' => $invite->status,
+                'token' => $invite->token,
+            ];
+        });
+        
+        
+        return response()->json($invitesTransformed);
+    }
+    
     
     
 }

--- a/app/Listeners/SendConfirmationEmail.php
+++ b/app/Listeners/SendConfirmationEmail.php
@@ -25,7 +25,7 @@ class SendConfirmationEmail
         $user = $event->user;
         
         $confirmUrl = URL::temporarySignedRoute(
-            'confirm.email',
+            'auth.confirm.email',
             now()->addDay(),
             ['user' => $user->id]
         );

--- a/app/Mail/InviteRegisteredUserMail.php
+++ b/app/Mail/InviteRegisteredUserMail.php
@@ -40,10 +40,10 @@ class InviteRegisteredUserMail extends Mailable
     public function content(): Content
     {
         return new Content(
-            markdown: 'emails.invite-registered-user',
+            view: 'emails.invite-registered-user',
             with: [
                 'invite' => $this->invite,
-                'eventUrl' => config('app.frontend_app.url'). "/dashboard/events/{$this->invite->event_id}",
+                'eventUrl' => config('app.frontend_app.url'). "dashboard/events/{$this->invite->event_id}",
             ],
         );
     }

--- a/app/Mail/InviteUnregisteredUserMail.php
+++ b/app/Mail/InviteUnregisteredUserMail.php
@@ -40,10 +40,10 @@ class InviteUnregisteredUserMail extends Mailable
     public function content(): Content
     {
         return new Content(
-            markdown: 'emails.invite-unregistered-user',
+            view: 'emails.invite-unregistered-user',
             with: [
                 'invite' => $this->invite,
-                'acceptUrl' => config('app.frontend_app.url'). "/invite?token={$this->invite->token}",
+                'acceptUrl' => config('app.frontend_app.url'). "event/{$this->invite->event->id}/invite?token={$this->invite->token}",
             ],
         );
     }

--- a/app/Models/EventCollaborationInvite.php
+++ b/app/Models/EventCollaborationInvite.php
@@ -83,6 +83,19 @@ class EventCollaborationInvite extends Model
     }
     
     /**
+     * Marks the current instance as declined by updating its status.
+     *
+     * @return void
+     */
+    public function markAsDeclined(): void
+    {
+        $this->update([
+            'status' => 'declined',
+        ]);
+    }
+    
+    
+    /**
      * Determines if the current instance is expired.
      *
      * @return bool True if expired, otherwise false.

--- a/database/migrations/2025_05_25_003047_create_event_collaboration_invites_table.php
+++ b/database/migrations/2025_05_25_003047_create_event_collaboration_invites_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->string('role')->default('viewer');
             
             $table->string('token')->unique();
-            $table->enum('status', ['pending', 'accepted', 'expired'])->default('pending');
+            $table->enum('status', ['pending', 'accepted', 'declined', 'expired'])->default('pending');
             
             $table->foreignId('invited_by_user_id')->constrained('users')->cascadeOnDelete();
             $table->unsignedTinyInteger('resend_count')->default(0);

--- a/database/seeders/EventUserRoleSeeder.php
+++ b/database/seeders/EventUserRoleSeeder.php
@@ -49,13 +49,14 @@ class EventUserRoleSeeder extends Seeder
             'add_song', 'delete_song', 'manage_playlist',
             
             // Location
-            'edit_location', 'add_location_photo',
+            'view_event_locations', 'create_event_locations', 'edit_event_locations',
             
             // RSVP
             'manage_rsvp', 'view_rsvp',
             
             // Collaboration
-            'manage_collaborators'
+            'manage_collaborators',
+            
         ];
         
         foreach ($permissions as $permission) {
@@ -76,7 +77,7 @@ class EventUserRoleSeeder extends Seeder
             'add_menu_item', 'edit_menu_item', 'delete_menu_item',
             'upload_photo', 'delete_photo', 'view_gallery',
             'add_song', 'delete_song', 'manage_playlist',
-            'edit_location', 'add_location_photo',
+            'view_event_locations', 'create_event_locations', 'edit_event_locations',
             'manage_rsvp', 'view_rsvp', 'manage'
         ]);
         

--- a/routes/api/app.php
+++ b/routes/api/app.php
@@ -67,6 +67,15 @@ Route::prefix('event/{event}')->name('event.')->group(function () {
     });
 });
 
+// Collaborators Routes
+Route::get('event/{event}/collaborators/invite/{token}', [InviteCollaboratorController::class, 'checkToken'])
+    ->name('collaborators.checkToken');
+Route::post('event/{event}/collaborators/invite/{token}/decline', [InviteCollaboratorController::class, 'declineInvite'])
+    ->name('collaborators.declineInvite');
+Route::get('collaborators/check-tokens', [InviteCollaboratorController::class, 'eventTokens'])
+    ->name('collaborators.eventTokens');
+
+
 // Protected Routes
 Route::middleware(['auth:sanctum', 'refresh.token'])->group(function () {
 


### PR DESCRIPTION
Added functionality to decline event collaboration invites and validate tokens. Introduced new API routes for managing collaborator invitations, refined invite status handling, and updated related email templates and seeder logic. Ensured compliance with frontend URL structures for invite links.