### PR TITLE
Fix incorrect column name in event user roles creation

### DIFF
--- a/app/Http/Services/AppServices/EventsServices.php
+++ b/app/Http/Services/AppServices/EventsServices.php
@@ -151,7 +151,7 @@ class EventsServices
             'event_id' => $event->id,
             'user_id' => $this->request->user()->id,
         ], [
-            'role' => Role::query()->where('name', 'owner')->first()->id,
+            'role_id' => Role::query()->where('name', 'owner')->first()->id,
         ]);
 
         return $event;


### PR DESCRIPTION
Updated `role` to `role_id` in `updateOrCreate` method to ensure correct database column usage for event user roles.